### PR TITLE
SAT-59 add snackbar

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,6 +1,7 @@
-pre-commit:
+pre-push:
   parallel: true
   commands:
     lint:
-      glob: '*.{ts,tsx}'
-      run: pnpm eslint {staged_files}
+      run: pnpm lint
+    test:
+      run: pnpm test

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -3,7 +3,7 @@ import { Box, createTheme, IconButton, ThemeProvider } from "@mui/material";
 import CSSBaseLine from "@mui/material/CssBaseline";
 import Brightness4Icon from "@mui/icons-material/Brightness4";
 import Brightness7Icon from "@mui/icons-material/Brightness7";
-import { useLocalStorage } from "@/utils/useLocalStorage";
+import { useLocalStorage, Snackbar } from "@/utils";
 // import { Register } from "@/pages/Register";
 // import { Register } from "@/pages/Register";
 import { Login } from "@/pages/Login";
@@ -53,6 +53,7 @@ function App() {
           </Box>
           <Login />
         </Box>
+        <Snackbar />
       </CSSBaseLine>
     </ThemeProvider>
   );

--- a/packages/client/src/store/index.ts
+++ b/packages/client/src/store/index.ts
@@ -1,1 +1,2 @@
 export { useBearsStore } from "./bearsStore";
+export { useSnackbarStore } from "./snackbarStore";

--- a/packages/client/src/store/snackbarStore.ts
+++ b/packages/client/src/store/snackbarStore.ts
@@ -1,0 +1,79 @@
+import { ReactNode } from "react";
+import { create } from "zustand";
+import { TNullable } from "@/utils";
+
+type TSeverity = "success" | "warning" | "error";
+
+type TAnchorOrigin = {
+  vertical: "top" | "bottom";
+  horizontal: "left" | "right";
+};
+
+type TButton = TNullable<ReactNode>;
+
+interface IOpenSnackbarProps {
+  message: string;
+  severity?: TSeverity;
+  button?: TButton;
+  anchorOrigin?: TAnchorOrigin;
+}
+
+interface IState extends Required<IOpenSnackbarProps> {
+  open: boolean;
+}
+
+interface IStore extends IState {
+  closeSnackbar: () => void;
+  openSnackbar: (props: IOpenSnackbarProps) => void;
+}
+
+const initialState: IState = {
+  open: false,
+  message: "",
+  severity: "success",
+  button: null,
+  anchorOrigin: { vertical: "top", horizontal: "right" },
+};
+
+/**
+ * Extract openSnackbar and use it to call snackbar:
+ * @example
+ * const openSnackbar = useSnackbarStore(({ openSnackbar }) => openSnackbar)
+ * openSnackbar({ message: "hello world!")
+ * @example
+ * const openSnackbar = useSnackbarStore(({ openSnackbar }) => openSnackbar)
+ * openSnackbar({ message: "hello world!", severity: "warning" })
+ * @example
+ * const openSnackbar = useSnackbarStore(({ openSnackbar }) => openSnackbar)
+ * openSnackbar({
+ *   message: "hello world!",
+ *   severity: "warning",
+ *   button: (
+ *     <Button onClick={() => console.log("hi!")}>Click me!</Button>
+ *   ),
+ *   anchorOrigin: {
+ *     vertical: "bottom",
+ *    horizontal: "right"
+ *   }
+ * })
+ */
+export const useSnackbarStore = create<IStore>()((set) => ({
+  ...initialState,
+  closeSnackbar() {
+    set({ open: false });
+  },
+  openSnackbar({
+    message = "",
+    severity = "success",
+    button = null,
+    anchorOrigin = { vertical: "top", horizontal: "right" },
+  }: IOpenSnackbarProps) {
+    set({
+      open: true,
+      message,
+      severity,
+      button,
+      anchorOrigin,
+    });
+  },
+}));

--- a/packages/client/src/utils/Snackbar.tsx
+++ b/packages/client/src/utils/Snackbar.tsx
@@ -1,0 +1,33 @@
+import { Alert, Snackbar as MuiSnackbar } from "@mui/material";
+import { useSnackbarStore } from "@/store";
+
+export function Snackbar() {
+  const {
+    open,
+    message,
+    severity,
+    button,
+    anchorOrigin,
+    closeSnackbar: handleClose,
+  } = useSnackbarStore((state) => state);
+
+  return (
+    <MuiSnackbar
+      open={open}
+      autoHideDuration={4000}
+      onClose={handleClose}
+      anchorOrigin={anchorOrigin}
+    >
+      <Alert
+        sx={{ width: "100%", bgcolor: `${[severity]}.light` }}
+        elevation={6}
+        variant="filled"
+        onClose={handleClose}
+        severity={severity}
+        action={button}
+      >
+        {message}
+      </Alert>
+    </MuiSnackbar>
+  );
+}

--- a/packages/client/src/utils/index.ts
+++ b/packages/client/src/utils/index.ts
@@ -1,1 +1,2 @@
 export { dummySayHi } from "./dummySayHi";
+export type { TNullable } from "./typeScriptUtils";

--- a/packages/client/src/utils/index.ts
+++ b/packages/client/src/utils/index.ts
@@ -1,2 +1,4 @@
 export { dummySayHi } from "./dummySayHi";
 export type { TNullable } from "./typeScriptUtils";
+export { useLocalStorage } from "./useLocalStorage";
+export { Snackbar } from "./Snackbar";

--- a/packages/client/src/utils/typeScriptUtils.ts
+++ b/packages/client/src/utils/typeScriptUtils.ts
@@ -1,0 +1,1 @@
+export type TNullable<T> = T | null;


### PR DESCRIPTION
Теперь можно пользоваться снекбаром!

Для этого необходимо выполнить следующие действия:

```jsx
import { useSnackbarStore } from "@/store";

function Component() {
  const openSnackbar = useSnackbarStore((store) => store.openSnackbar);

return <button onClick={() => openSnackbar({ message: "Hello World!" })}><Click me!</button>
}
```

![image](https://user-images.githubusercontent.com/117439163/216983383-69948df3-2d57-4581-90fd-4fb116c8d2ad.png)

Также пофикшен lefthook. Если раньше он не работал, то теперь работает на pre-push хук